### PR TITLE
Trigger Schedule should default to boolean

### DIFF
--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -55,7 +55,7 @@ variable "trigger_schedule" {
   type = "map"
 
   default = {
-    enabled = 0
+    enabled = false
   }
 }
 


### PR DESCRIPTION
Setting trigger schedule default to be boolean 'false' instead of '0'